### PR TITLE
Closes #36: add dotenv to Config class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 # Environment 
 .env/
+.env
 .venv/
 .vscode/
 .pytest_cache/

--- a/self_serve_platform/system/config.py
+++ b/self_serve_platform/system/config.py
@@ -19,6 +19,11 @@ from self_serve_platform.system.log import Logger
 
 logger = Logger().get_logger()
 
+from os.path import join, dirname
+from dotenv import load_dotenv
+
+dotenv_path = join(dirname(__file__), '.env')
+load_dotenv(dotenv_path)
 
 class Config:
     """


### PR DESCRIPTION
Resolving the environment variables from `.env` file, simplifies user setup.