### PR TITLE
Closes #37: Download and configure data files for tool_rag

### DIFF
--- a/3gpp.py
+++ b/3gpp.py
@@ -1,0 +1,29 @@
+from ftplib import FTP
+import os
+from posixpath import basename 
+import zipfile
+
+
+dest = "./examples/tool_rag/data"
+ftp = FTP('ftp.3gpp.org') 
+ftp.login()
+
+for ver in ["501", "502"]:
+    versions_path = f"Specs/archive/23_series/23.{ver}"
+    try:
+        document_versions = ftp.nlst(versions_path)
+        document_path = document_versions[-1]
+        target_file_path = os.path.join(dest, basename(document_path))
+
+        with open(target_file_path, "wb") as fp:
+            ftp.retrbinary(f'RETR {document_path}', fp.write)
+        with zipfile.ZipFile(target_file_path, 'r') as f:
+            # print(f"Extracting {f.filename}")
+            f.extractall(dest)
+        os.remove(target_file_path)
+        print(f"Update config.yaml with {basename(document_path).replace(".zip", ".docx")}")
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+ftp.quit()

--- a/3gpp.py
+++ b/3gpp.py
@@ -52,7 +52,7 @@ def main():
 
     # Re-write the config.yaml file with updated data
     with open(config_yaml, "wb") as f:
-        yaml.safe_dump(loaded, f, default_flow_style=False, explicit_start=True, allow_unicode=True, encoding="utf-8")
+        yaml.safe_dump(loaded, f, default_flow_style=False, explicit_start=True, allow_unicode=True, encoding="utf-8", sort_keys=False)
 
 if __name__ == "__main__":
     main()

--- a/3gpp.py
+++ b/3gpp.py
@@ -2,28 +2,57 @@ from ftplib import FTP
 import os
 from posixpath import basename 
 import zipfile
+import yaml
 
 
-dest = "./examples/tool_rag/data"
-ftp = FTP('ftp.3gpp.org') 
-ftp.login()
+def download_latest(series: str, version: str, destination: str):
 
-for ver in ["501", "502"]:
-    versions_path = f"Specs/archive/23_series/23.{ver}"
+    ftp = FTP('ftp.3gpp.org') 
+    ftp.login()
+
+    versions_path = f"Specs/archive/{series}_series/{series}.{version}"
     try:
         document_versions = ftp.nlst(versions_path)
         document_path = document_versions[-1]
-        target_file_path = os.path.join(dest, basename(document_path))
+        target_file_path = os.path.join(destination, basename(document_path))
 
         with open(target_file_path, "wb") as fp:
             ftp.retrbinary(f'RETR {document_path}', fp.write)
         with zipfile.ZipFile(target_file_path, 'r') as f:
             # print(f"Extracting {f.filename}")
-            f.extractall(dest)
+            f.extractall(destination)
         os.remove(target_file_path)
-        print(f"Update config.yaml with {basename(document_path).replace(".zip", ".docx")}")
+        # print(f"Update config.yaml with {basename(document_path).replace(".zip", ".docx")}")
+        yield basename(document_path).replace(".zip", ".docx")
 
     except Exception as e:
         print(f"Error: {e}")
 
-ftp.quit()
+    ftp.quit()
+
+def main():
+    destination = "examples/tool_rag/data"
+    config_yaml = "examples/tool_rag/config.yaml"
+    files = []
+
+    for version in ["501", "502"]:
+        for filename in download_latest(series="23", version=version, destination=destination):
+            files.append(filename)
+
+    if len(files) == 0:
+        print("No files downloaded.")
+        return
+
+    # Update config.yaml with new document name
+    with open(config_yaml) as f:
+        loaded = yaml.safe_load(f)
+        
+        loaded["data"]["files"] = [ {"source": filename} for filename in files ]
+        loaded["data"]["path"] = destination
+
+    # Re-write the config.yaml file with updated data
+    with open(config_yaml, "wb") as f:
+        yaml.safe_dump(loaded, f, default_flow_style=False, explicit_start=True, allow_unicode=True, encoding="utf-8")
+
+if __name__ == "__main__":
+    main()

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -12,6 +12,9 @@ tools_directories=(
 # Activate virtual environment 
 source .venv/bin/activate
 
+# Download example data files
+python ./3gpp.py # Download spec files for tool_rag example
+
 # Launch tools
 for dir in "${tools_directories[@]}"; do
     (


### PR DESCRIPTION
Automatically download latest spec files from 3GPP site and update `config.yaml` for simpler demo.
This change requires updates to Wiki page [Installation Guide](https://github.com/HewlettPackard/llmesh/wiki/Installation).